### PR TITLE
add koskeroglu

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ import (
 	"baklava/providers/karakoygulluoglu"
 	"baklava/providers/kocakbaklava"
 	"baklava/providers/celebiogullari"
+	"baklava/providers/koskeroglu"
 	"baklava/util"
 )
 
@@ -125,6 +126,7 @@ func run() error {
 		celebiogullari.CelebiogullariProvider{},
 		imamcagdas.ImamCagdasProvider{},
 		gaziantepgulluoglu.GaziantepGulluogluProvider{},
+		koskeroglu.KoskerogluProvider{},
 	} {
 		cost, err := v.FistikliBaklava()
 		if err != nil {

--- a/providers/koskeroglu/provider.go
+++ b/providers/koskeroglu/provider.go
@@ -1,0 +1,34 @@
+package koskeroglu
+
+import (
+	"baklava/providers/genericparser"
+	"github.com/Rhymond/go-money"
+	"net/url"
+)
+
+const (
+	fistikliBaklavaURL = "https://koskeroglu.com/urun/fistikli-baklava/"
+	kuruBaklavaURL     = "https://koskeroglu.com/urun/kuru-baklava/"
+	fistikDolamaURL    = "https://koskeroglu.com/urun/sarma/"
+	rendererProxyURL   = "https://renderer-proxy-sc2owh7ynq-uc.a.run.app/?selector=span.amount&url="
+)
+
+type KoskerogluProvider struct{}
+
+func (k KoskerogluProvider) Name() string { return "Koskeroglu" }
+
+func (k KoskerogluProvider) FistikliBaklava() (*money.Money, error) {
+	return k.parseProductPrice(fistikliBaklavaURL)
+}
+
+func (k KoskerogluProvider) KuruBaklava() (*money.Money, error) {
+	return k.parseProductPrice(kuruBaklavaURL)
+}
+
+func (k KoskerogluProvider) FistikDolama() (*money.Money, error) {
+	return k.parseProductPrice(fistikDolamaURL)
+}
+
+func (k KoskerogluProvider) parseProductPrice(u string) (*money.Money, error) {
+	return genericparser.GenericParser{}.FromURL(`bdi`, rendererProxyURL + url.QueryEscape(u))
+}


### PR DESCRIPTION
resolves #2 

I deployed a puppeteer renderer and element selector app to Cloud Run. We can use it for any other complex, JS rendering website.
Address: [https://renderer-proxy-sc2owh7ynq-uc.a.run.app](https://renderer-proxy-sc2owh7ynq-uc.a.run.app)

I also tried to map a custom domain for renderer.calgan.cloud but I gave up after 30 minutes SSL provisioning :D

![5vudga](https://user-images.githubusercontent.com/20268300/143785187-aa7eb1d0-e35d-42b5-b87e-afaadd17964c.jpg)
