### PR TITLE
Price display problem fix

### DIFF
--- a/providers/genericparser/base.go
+++ b/providers/genericparser/base.go
@@ -65,6 +65,11 @@ func (_ GenericParser) FromURL(selector, url string) (*money.Money, error) {
 		return r
 	}, t)
 
+	//if two zero not in end of string, add two zero at the end (problem with 1.070 TL price)
+	if !strings.HasSuffix(t, "00") {
+		t += "00"
+	}
+
 	price, err := strconv.ParseInt(t, 10, 64)
 	if err != nil {
 		return nil, fmt.Errorf("error transforming string to integer (from %v): %v", t, err)

--- a/providers/genericparser/base_test.go
+++ b/providers/genericparser/base_test.go
@@ -37,4 +37,7 @@ func TestGenericParser(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, priceFive.Display(), "₺480.00")
 
+	price_six, err := genericparser.GenericParser{}.FromURL(`#price_six`, server.URL)
+	assert.Nil(t, err)
+	assert.Equal(t, price_six.Display(), "₺1,070.00", "The two price should be the same.")
 }

--- a/providers/genericparser/test/mockTestPage.html
+++ b/providers/genericparser/test/mockTestPage.html
@@ -1,13 +1,17 @@
 <!DOCTYPE html>
 <html>
+
 <head>
     <title>Test page</title>
 </head>
+
 <body>
     <div id="price_one">1.045,00 <i class="fa fa-try"></i></div>
     <div id="price_two">650,00 TL</div>
     <div id="price_three"><span class="fw-black product-price" data-price="880">880</span> TL</div>
     <div id="price_four">77,00 <i class='fa fa-try'></i></div>
     <div id="price_five"><span class="woocommerce-Price-currencySymbol">₺</span>&nbsp;480,00</div>
+    <div id="price_six"><span class="woocommerce-Price-currencySymbol">₺</span>&nbsp;1.070</div>
 </body>
+
 </html>


### PR DESCRIPTION
The pistachio-stuffed dolma from the "imamcagdas" provider was priced at 1,070 TL, but the system mistakenly converted it to 10.70 TL. I noticed this and fixed it by adding two zeros at the end. I tested the correction, and it passed all the tests.

Also, I can't fix issues on the Gaziantepgulluoglu website because it's not working properly.