### PR TITLE
Remove fractional part in price

### DIFF
--- a/providers/genericparser/base.go
+++ b/providers/genericparser/base.go
@@ -57,6 +57,9 @@ func (_ GenericParser) FromURL(selector, url string) (*money.Money, error) {
 		t += "00"
 	}
 
+	// Remove fractional part
+	t,_,_ = strings.Cut(t, ",")
+
 	// Remove all non-digits
 	t = strings.Map(func(r rune) rune {
 		if !unicode.IsDigit(r) {

--- a/providers/genericparser/base_test.go
+++ b/providers/genericparser/base_test.go
@@ -40,4 +40,8 @@ func TestGenericParser(t *testing.T) {
 	price_six, err := genericparser.GenericParser{}.FromURL(`#price_six`, server.URL)
 	assert.Nil(t, err)
 	assert.Equal(t, price_six.Display(), "₺1,070.00", "The two price should be the same.")
+	
+	price_seven, err := genericparser.GenericParser{}.FromURL(`#price_seven`, server.URL)
+	assert.Nil(t, err)
+	assert.Equal(t, price_seven.Display(), "₺907.00", "The two price should be the same.")
 }

--- a/providers/genericparser/test/mockTestPage.html
+++ b/providers/genericparser/test/mockTestPage.html
@@ -12,6 +12,7 @@
     <div id="price_four">77,00 <i class='fa fa-try'></i></div>
     <div id="price_five"><span class="woocommerce-Price-currencySymbol">₺</span>&nbsp;480,00</div>
     <div id="price_six"><span class="woocommerce-Price-currencySymbol">₺</span>&nbsp;1.070</div>
+    <div id="price_seven">907,50 TL<i class="fa fa-try"></i></div>
 </body>
 
 </html>


### PR DESCRIPTION
The fractional part is causing unnecessary complexity, and it doesn't hold significant importance. Consequently, in my attempts to solve the problem, I opted to remove that portion.